### PR TITLE
Small fixes for the website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -118,9 +118,9 @@
             <div class="mt-5">
               <h3 class="h4 mb-2">Easy to install</h3>
               <p class="mb-0">
-                Ships as a single binary file (
+                Ships as a single binary file (&nbsp;
                 <code>cleo.asi</code>
-                ) that you need to copy to the game directory. Uninstalling is
+                &nbsp;) that you need to copy to the game directory. Uninstalling is
                 as easy as deleting the
                 <code>cleo.asi</code>
                 file. Works with <code>Windows D3D9 MSS 32bit</code> version of
@@ -152,7 +152,7 @@
                 CLEO Redux can interpret and execute text scripts written in the
                 language conforming to the
                 <a
-                  href="http://www.ecma-international.org/ecma-262/5.1"
+                  href="https://262.ecma-international.org/5.1/"
                   target="_blank"
                   >ECMAScript 5.1</a
                 >


### PR DESCRIPTION
Added a non-breaking space to `( cleo.asi )` and fixed the link to ECMA 5.1.